### PR TITLE
Lowers TC Cost of Syndicate Pocket Satellite

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1087,8 +1087,8 @@ var/list/uplink_items = list()
 	name = "Pocket Satellite"
 	desc = "A grenade which, when detonated in space, creates a circular station with radius 7. The station is loaded with self-powered computers, useful gear, and machinery as well as a teleporter beacon. Anyone right under it when it unfolds is crushed."
 	item = /obj/item/weapon/grenade/station
-	cost = 20
-	discounted_cost = 14
+	cost = 12
+	discounted_cost = 8
 	jobs_with_discount = list("Captain", "Head of Personnel")
 
 /datum/uplink_item/jobspecific/trader


### PR DESCRIPTION
For a gimmick item that sees next to no use and supplies a lot of already obtainable things, I think it will benefit from being cheaper for everyone.

Price changed from 20(14 with discount) to 12(8 with discount). This will allow you to buy something else alongside the base of operation, and might make it appealing.

<!-- [tweak]-->

:cl:
 * tweak: The TC cost of the Syndicate Pocket Satellite has been reduced.